### PR TITLE
Fix stale route chunk recovery

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -157,6 +157,57 @@ const router = createRouter({
 
 })
 
+const DYNAMIC_IMPORT_RELOAD_KEY =
+  'anhelo_dynamic_import_reload'
+
+function isDynamicImportError(error) {
+  const message = String(
+    error?.message || error || ''
+  )
+
+  return (
+    message.includes(
+      'Failed to fetch dynamically imported module'
+    ) ||
+    message.includes(
+      'Importing a module script failed'
+    ) ||
+    message.includes(
+      'error loading dynamically imported module'
+    )
+  )
+}
+
+router.onError((error, to) => {
+  if (!isDynamicImportError(error)) return
+
+  if (
+    sessionStorage.getItem(
+      DYNAMIC_IMPORT_RELOAD_KEY
+    ) === '1'
+  ) {
+    sessionStorage.removeItem(
+      DYNAMIC_IMPORT_RELOAD_KEY
+    )
+    return
+  }
+
+  sessionStorage.setItem(
+    DYNAMIC_IMPORT_RELOAD_KEY,
+    '1'
+  )
+
+  window.location.assign(
+    to.fullPath || window.location.pathname
+  )
+})
+
+router.afterEach(() => {
+  sessionStorage.removeItem(
+    DYNAMIC_IMPORT_RELOAD_KEY
+  )
+})
+
 /* ─────────────────────────────
    PROTEGER RUTAS
 ───────────────────────────── */


### PR DESCRIPTION
## Summary
- Adds Vue Router recovery for stale lazy-loaded route chunks after deploys.
- Adds Vercel SPA rewrites so direct reloads like /mascotas return the Vue app instead of 404.
- Loads pets from the remote animals API in production and shows loading/error states while the database request is running.
- Falls back to the local placeholder image when pet photo URLs are missing or invalid.

## Validation
- npm run build
- GET https://proyecto-pagina-web-anhelo-pets.onrender.com/api/animals?status=Todos