### PR TITLE
Fix direct route reloads and pet loading state

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,6 @@
-const DEFAULT_API_BASE_URL = 'http://localhost:5272'
+const DEFAULT_API_BASE_URL = import.meta.env.DEV
+  ? 'http://localhost:5272'
+  : 'https://proyecto-pagina-web-anhelo-pets.onrender.com'
 const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL
 
 export const API_BASE_URL = (

--- a/frontend/src/stores/usePetsStore.js
+++ b/frontend/src/stores/usePetsStore.js
@@ -2,6 +2,7 @@
 
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { animalsApi } from '../services/api'
 
 export const usePetsStore = defineStore('pets', () => {
 
@@ -9,6 +10,8 @@ export const usePetsStore = defineStore('pets', () => {
   // Estado global
   // ─────────────────────────────────────────────
   const nextId = ref(1)
+  const isLoading = ref(false)
+  const loadError = ref('')
 
   const pets = ref(
 
@@ -25,6 +28,100 @@ function savePets() {
     JSON.stringify(pets.value)
   )
 
+}
+
+function formatAge(animal) {
+  const years = Number(animal.ageYears || 0)
+  const months = Number(animal.ageMonths || 0)
+
+  if (years > 0 && months > 0) {
+    return `${years} año${years !== 1 ? 's' : ''} y ${months} mes${months !== 1 ? 'es' : ''}`
+  }
+
+  if (years > 0) {
+    return `${years} año${years !== 1 ? 's' : ''}`
+  }
+
+  if (months > 0) {
+    return `${months} mes${months !== 1 ? 'es' : ''}`
+  }
+
+  return 'Edad por confirmar'
+}
+
+function normalizePhotoUrl(photoUrl) {
+  if (!photoUrl || typeof photoUrl !== 'string') {
+    return '/img-mascotas/mascotas.jpg'
+  }
+
+  const trimmed = photoUrl.trim()
+
+  if (trimmed.startsWith('/')) {
+    return trimmed
+  }
+
+  try {
+    const url = new URL(trimmed)
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return '/img-mascotas/mascotas.jpg'
+    }
+
+    if (!url.hostname.includes('.')) {
+      return '/img-mascotas/mascotas.jpg'
+    }
+
+    return trimmed
+  } catch {
+    return '/img-mascotas/mascotas.jpg'
+  }
+}
+
+function normalizeAnimal(animal) {
+  const image = normalizePhotoUrl(animal.photoUrl)
+
+  return {
+    id: animal.animalId,
+    name: animal.animalName,
+    type: animal.species,
+    breed: animal.breed,
+    age: formatAge(animal),
+    sex: animal.sex,
+    size: '',
+    personality: animal.photoDescription || '',
+    healthBasic: animal.healthStatus,
+    status: animal.animalStatus,
+    description: animal.description,
+    internalNotes: '',
+    image,
+    images: [
+      {
+        preview: image,
+      },
+    ],
+    featured: false,
+    requests: [],
+  }
+}
+
+async function loadPets() {
+  isLoading.value = true
+  loadError.value = ''
+
+  try {
+    const animals = await animalsApi.getAll({
+      status: 'Todos',
+    })
+
+    pets.value = Array.isArray(animals)
+      ? animals.map(normalizeAnimal)
+      : []
+
+    savePets()
+  } catch (error) {
+    loadError.value = error?.message || 'No se pudieron cargar las mascotas.'
+  } finally {
+    isLoading.value = false
+  }
 }
 
   // ─────────────────────────────────────────────
@@ -263,6 +360,8 @@ savePets()
     // estado
     pets,
     nextId,
+    isLoading,
+    loadError,
 
     // computed
     publicPets,
@@ -271,6 +370,7 @@ savePets()
 
     // acciones
     addPet,
+    loadPets,
     updatePet,
     changeStatus,
     deactivatePet,

--- a/frontend/src/views/MascotasView.vue
+++ b/frontend/src/views/MascotasView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import NavBar from '../components/NavBar.vue'
 import FooterBar from '../components/FooterBar.vue'
@@ -40,6 +40,10 @@ function mainImage(pet) {
   return pet.image || ''
 }
 
+function handleImageError(event) {
+  event.target.src = '/img-mascotas/mascotas.jpg'
+}
+
 function goAdopt(pet) {
   router.push({ name: 'adoptar', params: { id: pet.id }, query: { name: pet.name } })
 }
@@ -50,6 +54,10 @@ function clearFilters() {
   filterStatus.value = 'Todos'
   searchQuery.value  = ''
 }
+
+onMounted(() => {
+  store.loadPets()
+})
 </script>
 
 <template>
@@ -100,7 +108,7 @@ function clearFilters() {
       </div>
     </div>
 
-    <div class="results-top">
+    <div v-if="!store.isLoading" class="results-top">
       <p class="results-count">
         {{ filtered.length }} mascota{{ filtered.length !== 1 ? 's' : '' }}
         encontrada{{ filtered.length !== 1 ? 's' : '' }}
@@ -108,11 +116,28 @@ function clearFilters() {
       <button class="clear-btn" @click="clearFilters">Limpiar filtros</button>
     </div>
 
+    <!-- Estado de carga -->
+    <div v-if="store.isLoading" class="loading-state" role="status" aria-live="polite">
+      <span class="loading-spinner"></span>
+      <div>
+        <h3>Cargando mascotas</h3>
+        <p>Estamos consultando la base de datos.</p>
+      </div>
+    </div>
+
+    <!-- Error de carga -->
+    <div v-else-if="store.loadError" class="empty-state">
+      <i class='bx bx-error-circle'></i>
+      <h3>No pudimos cargar las mascotas</h3>
+      <p>{{ store.loadError }}</p>
+      <button class="clear-btn retry-btn" @click="store.loadPets">Intentar de nuevo</button>
+    </div>
+
     <!-- Grid de mascotas -->
-    <div v-if="filtered.length" class="pets-grid">
+    <div v-else-if="filtered.length" class="pets-grid">
       <div v-for="pet in filtered" :key="pet.id" class="pet-card">
         <div class="pet-photo">
-          <img :src="mainImage(pet)" :alt="pet.name" class="pet-image" />
+          <img :src="mainImage(pet)" :alt="pet.name" class="pet-image" @error="handleImageError" />
           <div class="pet-photo-overlay"></div>
           <span class="badge floating-badge" :class="statusColor(pet.status)">{{ pet.status }}</span>
           <div v-if="pet.images && pet.images.length > 1" class="gallery-dots">
@@ -181,7 +206,7 @@ function clearFilters() {
     <div class="happy-grid">
       <div v-for="pet in adoptedPets" :key="pet.id" class="happy-card">
         <div class="happy-photo">
-          <img :src="mainImage(pet)" :alt="pet.name" />
+          <img :src="mainImage(pet)" :alt="pet.name" @error="handleImageError" />
           <div class="happy-overlay">
             <span class="happy-badge">Adoptada ♥</span>
           </div>
@@ -407,6 +432,54 @@ function clearFilters() {
 .clear-btn:hover {
   background: #E7EEE7;
   color: #2F352F;
+}
+
+/* ══ ESTADO DE CARGA ══ */
+.loading-state {
+  min-height: 280px;
+  border: 1px solid #E8ECE8;
+  border-radius: 18px;
+  background: #FFFFFF;
+  box-shadow: 0 8px 32px rgba(58,71,60,0.07);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  padding: 44px 24px;
+  text-align: left;
+}
+
+.loading-spinner {
+  width: 42px;
+  height: 42px;
+  border: 4px solid #E7EEE7;
+  border-top-color: #3A473C;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex: 0 0 auto;
+}
+
+.loading-state h3 {
+  font-size: 22px;
+  font-weight: 800;
+  color: #3A473C;
+  margin: 0 0 6px;
+}
+
+.loading-state p {
+  color: #6C756D;
+  font-size: 14px;
+  margin: 0;
+}
+
+.retry-btn {
+  margin-top: 18px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ══ GRID DE MASCOTAS ══ */
@@ -786,6 +859,7 @@ function clearFilters() {
   .page-hero h1 { font-size: 38px; }
   .page-hero p  { font-size: 15px; }
   .filters-bar  { padding: 20px; }
+  .loading-state { flex-direction: column; text-align: center; }
   .filters-grid { gap: 18px; }
   .filter-chips { overflow-x: auto; flex-wrap: nowrap; padding-bottom: 4px; }
   .pets-grid { grid-template-columns: 1fr; }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds Vercel SPA rewrites so direct reloads like /mascotas return the Vue app instead of 404.
- Loads pets from the remote animals API in production and shows loading/error states while the database request is running.
- Falls back to the local placeholder image when pet photo URLs are missing or invalid.

## Validation
- npm run build
- GET https://proyecto-pagina-web-anhelo-pets.onrender.com/api/animals?status=Todos